### PR TITLE
update KafkaConnect spec.build to use internal registry

### DIFF
--- a/charts/all/kafka/templates/kafkaConnect.yaml
+++ b/charts/all/kafka/templates/kafkaConnect.yaml
@@ -9,8 +9,7 @@ spec:
   bootstrapServers: '{{ .Values.kafka.cluster.name }}-kafka-bootstrap.kafka.svc.cluster.local:9093'
   build:
     output:
-      image: 'quay.io/jary/my-connect:latest'
-      pushSecret: jary-myconnectbot-pull-secret
+      image: 'image-registry.openshift-image-registry.svc:5000/rec-sys/connect-cluster:latest'
       type: docker
     plugins:
       - artifacts:


### PR DESCRIPTION
Use internal registry to push KafkaConnect plugin build instead of Quay so that we won't have to add any more secrets for Quay auth to the pattern execution.